### PR TITLE
Cached entity context calculation

### DIFF
--- a/Subscriber/DoctrineSubscriber.php
+++ b/Subscriber/DoctrineSubscriber.php
@@ -82,12 +82,19 @@ class DoctrineSubscriber implements EventSubscriber
     public function postFlush(PostFlushEventArgs $args)
     {
         $entityManager = $args->getEntityManager();
+        $contextsCache = array();
 
         foreach ($entityManager->getUnitOfWork()->getIdentityMap() as $key => $entities) {
             foreach ($entities as $entityId => $entity) {
                 $changeSet   = $entityManager->getUnitOfWork()->getEntityChangeSet($entity);
                 $entityClass = $this->contextService->resolveEntityClass(get_class($entity));
-                $contexts    = $this->contextService->getEntityContexts($entityClass);
+
+                if(isset($contextsCache[$entityClass])) {
+                    $contexts = $contextsCache[$entityClass];
+                } else {
+                    $contexts    = $this->contextService->getEntityContexts($entityClass);
+                    $contextsCache[$entityClass] = $contexts;
+                }
 
                 if (count($contexts) && count($changeSet)) {
                     $queued = $this->contextService->getQueued();


### PR DESCRIPTION
Sur l'import des établissements dans Hospitality, cette modification divise par deux le temps d'exécution, -53% de temps CPU. Le code actuel parse les annotations pour chaque entités qu'il doit gérer, les annotations dépendant de la classe il est inutile de les reparser pour plusieurs objets de la même classe.
Voir à l'avenir possibilité de mettre réellement en cache ces infos. Il faudra du coup creuser le fonctionnement de ce bundle.